### PR TITLE
Add git commit hash or tag name to latex header

### DIFF
--- a/workflow/resources/templates/showyourwork.sty
+++ b/workflow/resources/templates/showyourwork.sty
@@ -35,20 +35,34 @@
   }
 \fi
 
+% Check if the Git tag is set (i.e. is it an empty string)
+((* if repo.tag != "" *))
+\newcommand{\gitHeader}{((- repo.sha_tag_header -))}
+((* endif **))
+
 % Generic: replace \LaTeX with \Latex + showyourwork in \maketitle
 \let\oldmaketitle\maketitle
 \def\maketitle{%
     \let\oldLaTeX\LaTeX
+    \let\oldtoday\today
     \def\LaTeX{\oldLaTeX/\href{https://github.com/rodluger/showyourwork}{\showyourwork}}
+    ((* if repo.tag != "" *))
+      \renewcommand{\today}{\oldtoday;~\gitHeader}
+    ((* endif *))
     \oldmaketitle
     \let\LaTeX\oldLaTeX
+    \let\today\oldtoday
 }
 
 % MNRAS hack for displaying showyourwork logo
 \@ifclassloaded{mnras}{
   \ifx\CUP@mtlplain@loaded\undefined
     \def\@printed{Preprint \tod@y\
-      \qquad\qquad\qquad Compiled using \showyourwork/MNRAS \LaTeX\ style file v\@version}
+      \qquad\qquad\qquad Compiled using \showyourwork/MNRAS \LaTeX\ style file v\@version
+      ((* if repo.tag != "" *))
+      \,(\gitHeader)
+      ((* endif *))
+      }
   \else
     \def\@printed{}
   \fi

--- a/workflow/rules/config.py
+++ b/workflow/rules/config.py
@@ -9,7 +9,7 @@ values if none are provided. Current config options are
 - ``figexts`` (*list*): List of recognized figure extensions. Default
   is ``["pdf", "png", "eps", "jpg", "jpeg", "gif", "svg", "tiff"]``
 
-- ``arxiv_tarball_exclude`` (*list*): List of files/paths to exclude from 
+- ``arxiv_tarball_exclude`` (*list*): List of files/paths to exclude from
   the tarball.
 
 - ``tectonic_latest`` (*bool*): Use the latest version of ``tectonic`` (built
@@ -31,6 +31,12 @@ values if none are provided. Current config options are
 
 - ``download_only`` (*bool*): Only download Zenodo dependencies (never try
   to generate and/or upload them). Default False.
+
+- ``style`` (*dict*): Custom modifications to the stylesheet
+
+    - ``show_git_sha_or_tag`` (*bool*): Show the Git SHA in the article header.
+      If the HEAD commit corresponds to a Git tag, show the tag name in the
+      header.
 
 """
 from pathlib import Path
@@ -123,3 +129,9 @@ config["scripts"]["py"] = config["scripts"].get(
 #: Article name
 config["ms"] = config.get("ms", "src/ms.tex")
 config["ms_name"] = Path(config["ms"]).relative_to("src").name
+
+#: Latex style customization
+config["style"] = config.get("style", {})
+config["style"]["show_git_sha_or_tag"] = (
+    str(config["style"].get("show_git_sha_or_tag", True)).lower() == "true"
+)

--- a/workflow/rules/git.py
+++ b/workflow/rules/git.py
@@ -63,6 +63,26 @@ def get_repo_sha():
     return sha
 
 
+def get_repo_tag():
+    """
+    Return a tag name if the HEAD corresponds to a tagged version.
+
+    """
+    try:
+        tag = (
+            subprocess.check_output(
+                ["git", "describe", "--exact-match", "--tags", "HEAD"],
+                stderr=subprocess.DEVNULL
+            )
+            .decode()
+            .strip()
+        )
+    except Exception:
+        tag = ""
+
+    return tag
+
+
 def get_script_status(script):
     """
     Return an error code corresponding to the git status of a given script.

--- a/workflow/rules/metadata.smk
+++ b/workflow/rules/metadata.smk
@@ -10,7 +10,7 @@ rule metadata:
     Generates article metadata from the output of the ``repo``
     and ``script_info`` rules. Saves it as a JSON in the temporary
     ``showyourwork`` directory.
-    
+
     """
     message:
         "Generating article metadata..."
@@ -31,6 +31,19 @@ rule metadata:
         with open(relpaths.temp / "scripts.json", "r") as f:
             scripts = json.load(f)
         meta = dict(repo=repo)
+
+        # TODO: expose config by sharing it in meta, or construct this here?
+        meta["repo"]["sha_tag_header"] = ""
+        if config["style"]["show_git_sha_or_tag"]:
+            if meta["repo"]["tag"] != "":
+                meta["repo"]["sha_tag_header"] = (
+                    f'Git tag: {meta["repo"]["tag"]}'
+                )
+            else:
+                # The git default short hash is the first 7 characters:
+                meta["repo"]["sha_tag_header"] = (
+                    f'Git commit: {meta["repo"]["sha"][:7]}'
+                )
 
         # Miscellaneous
         meta["CI"] = os.getenv("CI", "false") == "true"

--- a/workflow/rules/repo.smk
+++ b/workflow/rules/repo.smk
@@ -20,5 +20,6 @@ rule repo:
         repo["sha"] = get_repo_sha()
         repo["url"] = get_repo_url()
         repo["branch"] = get_repo_branch()
+        repo["tag"] = get_repo_tag()
         with open(relpaths.temp / "repo.json", "w") as f:
             print(json.dumps(repo, indent=4), file=f)


### PR DESCRIPTION
Here's a go at adding the git commit (short) hash, or a git tag name to the Latex header! I have no idea how to test this - let me know how I should test it, as it's currently untested :)