### PR TITLE
Hack to ignore orcid-id file in other_filenames

### DIFF
--- a/workflow/rules/script_info.smk
+++ b/workflow/rules/script_info.smk
@@ -76,8 +76,8 @@ checkpoint script_info:
                             "{}.{}".format(relpaths.figures / label, ext), []
                         )
                         datasets = [
-                            dataset for dataset in alldeps 
-                            if type(dataset) is str and 
+                            dataset for dataset in alldeps
+                            if type(dataset) is str and
                             dataset.endswith(".zenodo")
                         ]
 
@@ -98,13 +98,13 @@ checkpoint script_info:
                                     figures[label]["datasets"].append(ds)
                         else:
                             figures[label] = {
-                                "script": script, 
-                                "files": filenames, 
+                                "script": script,
+                                "files": filenames,
                                 "datasets": datasets
                             }
 
         # Other figures
-        other_filenames = []
+        other_filenames = set()
 
         # Parse graphics labeled with fig* inside `figure` environments
         # These won't be automatically generated, but we still
@@ -118,7 +118,7 @@ checkpoint script_info:
                     if str(path) == "figures/dag.pdf":
                             continue
                     elif path.parts[0] == "figures":
-                        other_filenames.append(str(relpaths.src / path))
+                        other_filenames.add(str(relpaths.src / path))
                     elif path.parts[0] == "static":
                         continue
                     elif path.name in files.special_figures:
@@ -135,7 +135,9 @@ checkpoint script_info:
             if str(path) == "figures/dag.pdf":
                 continue
             elif path.parts[0] == "figures":
-                other_filenames.append(str(relpaths.src / path))
+                if path.parts[-1].startswith('orcid-id.'):
+                    continue
+                other_filenames.add(str(relpaths.src / path))
             elif path.parts[0] == "static":
                 continue
             elif path.name in files.special_figures:
@@ -148,7 +150,7 @@ checkpoint script_info:
         if len(other_filenames):
             figures["unknown"] = {
                 "script": files.unknown,
-                "files": other_filenames,
+                "files": list(other_filenames),
                 "datasets": []
             }
 


### PR DESCRIPTION
In the [astropy paper](https://github.com/astropy/astropy-v5.0-paper) build, for some reason the orcid-ID.png file was getting picked up by this rule and added to `other_filenames` (as many times as I have authors in my manuscript file). This does two things: switches to using a `set()`, because I don't think there's a reason to have duplicates in `other_filenames`, and adds a hack to check if the file considered is the orcid-ID file (and if so ignores it). I know this is a brittle change / hack, but it works for me locally. And I know this repo is deprecated, but if we can get some fix in for this it would be easier than switching over to the new system (for this paper)...